### PR TITLE
smc_run: Fix for single quotes in parameters

### DIFF
--- a/smc_run
+++ b/smc_run
@@ -70,8 +70,7 @@ while getopts "dhr:t:v" opt; do
 done
 
 shift $(expr $OPTIND - 1);
-command_line=$@
-if [ "$command_line" == "" ]; then
+if [ $# -eq 0 ]; then
 	echo "`basename "$0"`: Error: Missing command parameter";
 	exit 1;
 fi
@@ -82,5 +81,5 @@ export SMC_DEBUG;
 #
 export LD_PRELOAD=$LD_PRELOAD:$LIB_NAME;
 
-exec $command_line
+exec "$@"
 exit $?;


### PR DESCRIPTION
smc_run does not handle single quotes correctly, strings in single
quotes are treated as two arguments, such as:

smc_run wrk http://127.0.0.1/ -t64 -c 1000 -d 10 -H 'Connection: Close'

This patch fixes it by passing parameters to exec directly and keep them
as them are. Also remove the unused command_line variable.

Signed-off-by: Tony Lu <tonylu@linux.alibaba.com>