### PR TITLE
adjust default library path for Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ STUFF_32BIT	  = 0
 #
 ifeq ($(ARCH),64)
 ifeq ($(DISTRO),Ubuntu)
-LIBDIR		= ${PREFIX}/lib
+LIBDIR		= ${PREFIX}/usr/lib
 else
 LIBDIR		= ${PREFIX}/lib64
 endif

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ STUFF_32BIT	  = 0
 #
 ifeq ($(ARCH),64)
 ifeq ($(DISTRO),Ubuntu)
-LIBDIR		= ${PREFIX}/lib/${ARCHTYPE}-linux-gnu
+LIBDIR		= ${PREFIX}/lib
 else
 LIBDIR		= ${PREFIX}/lib64
 endif


### PR DESCRIPTION
Adjust default library path for Ubuntu
As of today the default library path for Ubuntu in smc-tools is
lib/${ARCHTYPE}-linux-gnu (which expands to lib/s390-linux-gnu),
but for other distributions it's /lib64.
However, according to the Debian Policy it should be /usr/lib.
This commit changes the default path on Ubuntu from
lib/${ARCHTYPE}-linux-gnu to /usr/lib.