### PR TITLE
util: fix build with CFLAGS="-g"

### DIFF
--- a/util.h
+++ b/util.h
@@ -33,7 +33,7 @@ char* trim_space(char *str);
 int get_abbreviated(uint64_t num, int max_digs, char *res);
 int contains(const char *prfx, const char *str);
 
-inline int is_str_empty(char *str)
+static inline int is_str_empty(char *str)
 {
 	if (str && str[0] == '\0')
 		return 1;


### PR DESCRIPTION
The build process fails with debug symbols enabled, at least on my system.
`CFLAGS="-g" make V=1`:
```
cc -g -DSMC_TOOLS_RELEASE=1.8.3 -I/usr/include/libnl3  smcd.o infod.o ueidd.o seidd.o devd.o linkgroupd.o statsd.o libnetlink.o util.o  -lnl-genl-3 -lnl-3 -lm -o smcd
[...]
/home/user/smc-tools/dev.c:151:(.text+0x246): undefined reference to `is_str_empty'
```

It appears the root cause is that `CFLAGS=-g` influences the compiler's inlining decisions, leading to a situation where the `is_str_empty` function is not inlined, and the linker is searching for an out-of-line definition that isn’t present.

The most straightforward fix is to declare this function `static inline`.