### PR TITLE
libnetlink: fix gen_nl_open() declaration

### DIFF
--- a/libnetlink.h
+++ b/libnetlink.h
@@ -60,7 +60,7 @@ int rtnl_dump(struct rtnl_handle *rth, void (*handler)(struct nlmsghdr *nlh));
 void parse_rtattr(struct rtattr *tb[], int max, struct rtattr *rta, int len);
 int sockdiag_send(int fd, unsigned char cmd);
 void set_extension(int ext);
-int gen_nl_open();
+int gen_nl_open(char *pname);
 void gen_nl_close();
 int gen_nl_handle(int cmd, int nlmsg_flags,
 		  int (*cb_handler)(struct nl_msg *msg, void *arg), void *arg);


### PR DESCRIPTION
A mismatch between a declaration and a definition of a function is an error in the C23 standard. Fix that for gen_nl_open() as GCC 15 now complains about it.