### PR TITLE
smc_run: support IPPROTO_SMC

### DIFF
--- a/smc-preload.c
+++ b/smc-preload.c
@@ -29,6 +29,10 @@
 #define AF_SMC 43
 #endif
 
+#ifndef IPPROTO_SMC
+#define IPPROTO_SMC 256
+#endif
+
 #ifndef SMCPROTO_SMC
 #define SMCPROTO_SMC		0	/* SMC protocol, IPv4 */
 #define SMCPROTO_SMC6		1	/* SMC protocol, IPv6 */
@@ -40,6 +44,7 @@ static void *dl_handle = NULL;
 static void initialize(void);
 
 static int debug_mode = 0;
+static int sk_family;
 
 #define GET_FUNC(x) \
 if (dl_handle) { \
@@ -106,12 +111,15 @@ int socket(int domain, int type, int protocol)
 	    (type & 0xf) == SOCK_STREAM &&
 	    (protocol == IPPROTO_IP || protocol == IPPROTO_TCP)) {
 		dbg_msg(stderr, "libsmc-preload: map sock to AF_SMC\n");
-		if (domain == AF_INET)
-			protocol = SMCPROTO_SMC;
-		else /* AF_INET6 */
-			protocol = SMCPROTO_SMC6;
-
-		domain = AF_SMC;
+		if (sk_family == AF_SMC) {  /* using AF_SMC */
+			if (domain == AF_INET)
+				protocol = SMCPROTO_SMC;
+			else /* AF_INET6 */
+				protocol = SMCPROTO_SMC6;
+			domain = AF_SMC;
+		} else {
+			protocol = IPPROTO_SMC;
+		}
 	}
 
 	rc = (*orig_socket)(domain, type, protocol);
@@ -131,6 +139,35 @@ static void set_debug_mode(const char *var_name)
 	debug_mode = 0;
 	if (var_value != NULL)
 		debug_mode = (var_value[0] != '0');
+}
+
+static void __attribute__ ((constructor)) init_sock_family(void)
+{
+	char *var_value;
+	int fd;
+
+	var_value = getenv("SMC_SOCK_FAMILY");
+
+	if (!var_value) { /* default to AF_SMC still */
+		goto select_af_smc ;
+	} else if (strncmp(var_value, "inet", sizeof("inet" - 1)) == 0) {
+		goto select_af_inet;
+	} else if (strncmp(var_value, "smc", sizeof("smc" - 1)) == 0) {
+		goto select_af_smc;
+	} else if (strncmp(var_value, "auto", sizeof("auto" - 1)) == 0) {
+		/* check whether IPPROTO_SMC was support */
+		fd = socket(AF_INET, SOCK_STREAM, IPPROTO_SMC);
+		if (fd >= 0) {
+			close(fd);
+			goto select_af_inet;
+		}
+	}
+select_af_smc:
+	sk_family = AF_SMC;
+	return;
+select_af_inet:
+	sk_family = AF_UNSPEC;
+	return;
 }
 
 static void initialize(void)

--- a/smc_run
+++ b/smc_run
@@ -24,6 +24,14 @@ function usage() {
         echo "   -r <SIZE>  request receive buffer size in Bytes";
         echo "   -t <SIZE>  request transmit buffer size in Bytes";
         echo "   -v         display version info";
+        echo "   -f <inet | smc | auto> specify the address type of SMC socket";
+}
+
+function check_family() {
+	case "$1" in
+		inet|smc|auto) ;;
+		*) "Error: parameter must be one of inet, smc, or auto, but got '$1'"; exit 1;;
+	esac
 }
 
 function check_size() {
@@ -50,7 +58,7 @@ function adjust_core_net_max() {
 # if necessary.
 #
 SMC_DEBUG=0;
-while getopts "dhr:t:v" opt; do
+while getopts "dhr:t:vf:" opt; do
 	case $opt in
 		d)
 			SMC_DEBUG=1;;
@@ -62,6 +70,8 @@ while getopts "dhr:t:v" opt; do
 		t)	check_size $OPTARG;
 			adjust_core_net_max wmem $OPTARG;
 			export SMC_SNDBUF=$OPTARG;;
+		f)	check_family $OPTARG;
+			export SMC_SOCK_FAMILY=$OPTARG;;
 		v)	echo "smc_run utility, smc-tools-$VERSION";
 			exit;;
 		\?)	echo "`basename "$0"`: Error: Invalid option: -$OPTARG";


### PR DESCRIPTION
Allow to create socket with IPPROTO_SMC by smc_run.

Usage: smc_run -f inet COMMAND
Usage: smc_run -f auto COMMAND